### PR TITLE
fix(project-version): report version number alignment

### DIFF
--- a/src/commands/project/version/bump.ts
+++ b/src/commands/project/version/bump.ts
@@ -533,7 +533,7 @@ class ReportGenerator {
     public printUpdatedPackages(): void {
         SFPLogger.log(COLOR_KEY_MESSAGE(`\nPackage versions updated:`), LoggerLevel.INFO);
         this.updatedPackages.forEach((pkg) => {
-            this.table.push([pkg.packageName, pkg.print()]);
+            this.table.push([pkg.packageName, ...pkg.print().split(' ')]);
         });
 
         SFPLogger.log(this.table.toString(), LoggerLevel.INFO);
@@ -547,17 +547,19 @@ class ReportGenerator {
         SFPLogger.log(COLOR_KEY_MESSAGE(`\nDependencies updated:`), LoggerLevel.INFO);
 
         this.updatedDependencies.forEach((pkg) => {
-            this.dependenciesTable.push([pkg.packageName, pkg.print()]);
+            this.dependenciesTable.push([pkg.packageName, ...pkg.print().split(' ')]);
 
             pkg.dependencies.forEach((dependency) => {
                 if (!dependency.isUpdated) {
                     return;
                 }
 
-                this.dependenciesTable.push([
-                    chalk.dim(` ${this._arrow}  ${dependency.packageName}`),
-                    chalk.dim(dependency.print(chalk.cyan.yellow)),
-                ]);
+                this.dependenciesTable.push(
+                    [
+                        ` ${this._arrow}  ${dependency.packageName}`,
+                        ...dependency.print(chalk.cyan.yellow).split(' '),
+                    ].map((value) => chalk.dim(value))
+                );
             });
         });
         SFPLogger.log(this.dependenciesTable.toString(), LoggerLevel.INFO);
@@ -573,12 +575,12 @@ class ReportGenerator {
 
     private printHumanReport() {
         this.table = new Table({
-            head: ['Package', 'Version'],
+            head: ['Package', 'Version', '', ''],
             chars: ZERO_BORDER_TABLE,
         });
 
         this.dependenciesTable = new Table({
-            head: ['Package', 'Version'],
+            head: ['Package', 'Version', '', ''],
             chars: ZERO_BORDER_TABLE,
         });
 


### PR DESCRIPTION
## Summary

This pull request includes changes to the `ReportGenerator` class in the `src/commands/project/version/bump.ts` file to improve the formatting of the printed tables by splitting package details into multiple columns.

Changes to table formatting:

* Modified the `printUpdatedPackages` method to split the package details into multiple columns when pushing to `this.table`.
* Updated the `printUpdatedDependencies` method to split the dependency details into multiple columns and apply dimming to each value individually.
* Adjusted the headers of both `this.table` and `this.dependenciesTable` in the `printHumanReport` method to accommodate the additional columns.

#### Checklist
All items have to be completed before a PR is merged

- [x] Adhere to [Contribution Guidelines](https://docs.flxbl.io/about-us/contributing-to-fxlbl)
- [ ] Updates to Decision Records considered?
- [ ] Updates to documentation at [flxbl-sfp Guide](https://github.com/flxbl-io/docs-sfp) considered?
- [ ] Tested changes?
- [ ] Unit Tests new and existing passing locally?
